### PR TITLE
stereo sound during playWave

### DIFF
--- a/TransShiftMex/Audapter.cpp
+++ b/TransShiftMex/Audapter.cpp
@@ -2272,7 +2272,8 @@ int Audapter::handleBufferWavePB(dtype *inFrame_ptr, dtype *outFrame_ptr, int fr
 	int n;
 
 	for(n=0;n<frame_size;n++){
-		outFrame_ptr[n]=data_pb[pbCounter];
+		//outFrame_ptr[n]=data_pb[pbCounter];
+		outFrame_ptr[2 * n] = outFrame_ptr[2 * n + 1] = data_pb[pbCounter];
 		pbCounter=pbCounter+1;
 		if (pbCounter==maxPBSize){
 			pbCounter=0;

--- a/TransShiftMex/mexLibrary.cpp
+++ b/TransShiftMex/mexLibrary.cpp
@@ -467,6 +467,7 @@ void mexFunction( int nlhs, mxArray *plhs[],
 			devpar.chans = 1;
 			audio_obj.setdevparams(&devpar,1);
 			devpar.num = activeDeviceNum;
+			devpar.chans = 2; // added for stereo output
 			audio_obj.setdevparams(&devpar,2);
 
 			if (!started) {


### PR DESCRIPTION
This PR attempts to address an issue which was fixed in our MRI mex file, but not in the "master" branch or other branches of this repo.

The issue is that when using Audapter's "playWave" functionality (`Audapter('playWave')`, which simply plays back an existing audio recording), the output is mono in the left speaker, rather than stereo.

**NOTE** that my testing seemed to show that additional changes need to be made before this code works properly. When I tried to test (albeit, having not used the playWave functionality before...), the output was still mono in the left speaker, AND there was a static-y buzz that was not present before. I can't say at this time if that's due to improper testing, or errors in the code.

I tried to test it this way:

- open audapter_matlab\mcode\audapterDemo_online.m
- Change your Matlab current folder so that the above file is in your current folder (i.e., be inside mcode)
- on L3, change audioInterfaceName to be 'Focusrite USB'
- run `audapterDemo_online('playWave')`

The stereoMode param defaults to 1 (stereo), so it should be playing stereo. I also tried with another audio file, with same results.